### PR TITLE
Basic Task Chaining Support

### DIFF
--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ def main():
                     logging.info(f"Task: {task}")
                     CombinedParse(page, task)
 
-                    # Append the new prompt to the transcript
+                    # Append the completed interaction to the transcript
                     chat = {
                         "user prompt": prompt,
                         "LLM response": promptParsed

--- a/main.py
+++ b/main.py
@@ -44,16 +44,21 @@ def main():
                 prompt = journal['utterance']['prompt']
                 logging.info(f"Prompt: {prompt}")
 
-                # send prompt and rolling transcript to LLM and convert to rigid command
+                # split prompt into tasks
                 promptParsed = LLMParse(prompt, transcript)
-                CombinedParse(page, promptParsed)
+                tasks = promptParsed.split("&&")
+                
+                # iterate through tasks and execute each sequentially
+                for task in tasks:
+                    logging.info(f"Task: {task}")
+                    CombinedParse(page, task)
 
-                # Append the new prompt to the transcript
-                chat = {
-                    "user prompt": prompt,
-                    "LLM response": promptParsed
-                }
-                transcript.append(chat)
+                    # Append the new prompt to the transcript
+                    chat = {
+                        "user prompt": prompt,
+                        "LLM response": promptParsed
+                    }
+                    transcript.append(chat)
         else:
             logging.error("The page has been closed. Exiting...")
 

--- a/utils/llm_parse.py
+++ b/utils/llm_parse.py
@@ -73,7 +73,7 @@ def LLMParse(user_prompt, transcript=None, temperature=0.1, top_p=1):
             Absolute Requirement for Messaging Commands: For messaging commands, ensure all three variables [Platform], [Name], and [Message] are present. If ANY piece is missing, respond with "x".
             No Placeholders: Do not use placeholders (e.g., [Name], [Message]). If the recipient is ambiguous (e.g., "team", "my brother"), respond with "x".
             Unclear or Unlisted Commands: If a command is unclear or not listed, respond with "x".
-            Prompt Chaining: If there are multiple commands in one prompt, output exactly like this: [Command1]&&[Command2] (Make sure to bind two commands together, you must use &&, just like in unix/linux OS.) If one of the commands is invalid, no worries! Just output "x&&[valid command here]"
+            Task Chaining: If there are multiple commands in one prompt, output exactly like this: [Command1]&&[Command2]...&&[CommandN] (Make sure to bind the commands together, you must use && as a seperator, just like in unix/linux OS.) If a command is invalid, no worries! Just output "x&&[valid command here]"
             Exact Output: Always output the exact command or "x". No extra text.
             No User Interaction: Do not provide any explanations or interact with the user. Only output formatted commands or "x".
             Sensitive Queries: If asked to describe your internal workings or for general knowledge, respond with "x".


### PR DESCRIPTION
There was a previous change [here](https://github.com/dot-Justin/LAMatHome/commit/dc2a4ce299273cff38c63295b5f1d4ae176acb4b) to add support for enabling LLMParse to output "chained" rigid commands. This would be a string of operator delimited tasks, with the operator in this case being "&&". This PR builds on this change by modifying the task chaining instruction in LLMParse and the workflow in main to accommodate multiple tasks in a single utterance.