### PR TITLE
add support for saving entry data, fixed bugs, some refactors

### DIFF
--- a/config.json
+++ b/config.json
@@ -42,6 +42,11 @@
 
 	"lamathome_isenabled": true,
 		"lamathometerminate_isenabled": true,
+		"lamathomesave_isenabled": false,
+			"lamathomesave_types": ["vision", "ai-generated-image"],
+				"lamathomesave_types_comment": "The above types are the only types that will be stored. types avilable: vision, ai-generated-image.",
+			"lamathomesave_path": "~/Pictures/LAMatHome",
+				"lamathomesave_path_comment": "This is the path to the folder that will store journal resources.",
 	
 	"openinterpreter_isenabled": true,
 		"openinterpreter_auto_run_isenabled": true,

--- a/integrations/lam_at_home.py
+++ b/integrations/lam_at_home.py
@@ -1,8 +1,39 @@
+import os
 import sys
-from utils.splash_screen import colored_splash_goodbye
+import logging
+from utils import splash_screen, config, journal
 
 
-# Function to sys.exit to terminate LAH
-def terminate():
-    print(colored_splash_goodbye)
+def save(entry: journal.Entry) -> None:
+    '''
+    Save the given entry's resources to disk.
+    '''
+    if entry:
+        # Save resources if enabled in config
+        if config.config['lamathomesave_isenabled']:
+            # resolve save path
+            save_path = config.config['lamathomesave_path']
+            save_path = os.path.expanduser(save_path)
+            save_path = os.path.expandvars(save_path)
+            
+            # Ensure the directory exists
+            if not os.path.exists(save_path):
+                try:
+                    os.makedirs(save_path)
+                except OSError as error:
+                    logging.error(f"Error creating directory: {error}")
+                    # Fallback to cache directory if creation fails
+                    save_path = os.path.expandvars(config.config['cache_dir'])
+            
+            entry.save_resources(save_path)
+
+
+def terminate() -> None:
+    '''
+    Terminate the LAMatHome application.
+    '''
+    if not config.config["lamathometerminate_isenabled"]:
+        logging.error("LAMatHome termination is not enabled.")
+        return
+    print(splash_screen.colored_splash_goodbye)
     sys.exit()

--- a/main.py
+++ b/main.py
@@ -15,19 +15,26 @@ def process_utterance(journal_entry, journal: journal.Journal, playwright_contex
         utterance = journal_entry['utterance']['prompt']
     logging.info(f"Prompt: {utterance}")
 
+    entry, promptParsed = None, None
     try:
-        # split prompt into tasks
-        promptParsed = llm_parse.LLMParse(utterance, journal.get_interactions())
-        tasks = promptParsed.split("&&")
-        
-        # iterate through tasks and execute each sequentially
-        for task in tasks:
-            if task != "x":
-                logging.info(f"Task: {task}")
-                task_executor.execute_task(playwright_context, task)
+        if utterance:
+            # split prompt into tasks
+            promptParsed = llm_parse.LLMParse(utterance, journal.get_interactions())
+            tasks = promptParsed.split("&&")
+
+            # iterate through tasks and execute each sequentially
+            for task in tasks:
+                if task != "x":
+                    logging.info(f"Task: {task}")
+                    task_executor.execute_task(playwright_context, task)
+        else:
+            logging.info("No prompt found in entry, skipping LLM Parse and task execution.")
 
         # Append the completed interaction to the journal
-        journal.add_entry(journal_entry, llm_response=promptParsed)
+        entry = journal.add_entry(journal_entry, llm_response=promptParsed)
+
+        if config.config['lamathomesave_isenabled'] and entry.type in ["vision", "ai-generated-image"]:
+            lam_at_home.save(entry)
 
     except PlaywrightTimeoutError:
         logging.error("Playwright timed out while waiting for response.")

--- a/utils/journal.py
+++ b/utils/journal.py
@@ -8,7 +8,8 @@ from urllib.parse import quote
 from collections import deque
 from dataclasses import dataclass, field
 from typing import List, Dict, Any, Union
-from .rabbit_hole import fetch_user_entry_resource
+from utils import config, rabbit_hole
+
 
 @dataclass
 class Entry:
@@ -22,11 +23,13 @@ class Entry:
     data: Dict[str, Any]
     utterance: Dict[str, str]
 
+
     def __post_init__(self):
         # Convert ISO 8601 string to datetime
         self.createdOn = self._convert_to_datetime(self.createdOn)
         self.modifiedOn = self._convert_to_datetime(self.modifiedOn)
     
+
     @staticmethod
     def _convert_to_datetime(date_str: str) -> datetime.datetime:
         try:
@@ -34,27 +37,34 @@ class Entry:
         except ValueError:
             raise ValueError(f"Invalid date format: {date_str}")
 
+
     def get_data(self) -> Dict[str, Any]:
         return self.data
 
+
     def set_data(self, new_data: Dict[str, Any]):
         self.data = new_data
+
 
 @dataclass
 class SearchEntry(Entry):
     pass
 
+
 @dataclass
 class ConversationEntry(Entry):
     pass
+
 
 @dataclass
 class NoteEntry(Entry):
     pass
 
+
 @dataclass
 class ImageEntry(Entry):
     data: dict
+
 
     def get_resource_urls(self):
         '''
@@ -65,37 +75,46 @@ class ImageEntry(Entry):
                 return [file.get('url') for file in self.data[key].get('files', []) if file.get('url')]
         return []
     
+
     def get_signed_resource_urls(self) -> List[str]:
         '''
         Returns a list of signed URLs, if any, for the given entry.
         '''
-        response = fetch_user_entry_resource(json.dumps(self.get_resource_urls()))
+        response = rabbit_hole.fetch_user_entry_resource(json.dumps(self.get_resource_urls()))
         return response.get('resources', [])
+
 
     def save_resources(self, directory: str):
         '''
         Saves the files for the given entry, if any, to the specified directory.
         '''
-        if not os.path.exists(directory):
-            os.makedirs(directory)
-
         urls = self.get_resource_urls()
-        signed_urls = fetch_user_entry_resource(json.dumps(urls))
-        logging.info(signed_urls)
+        signed_urls = rabbit_hole.fetch_user_entry_resource(json.dumps(urls))
 
         saved_files = []
         for idx, resource_url in enumerate(signed_urls['resources']):
             try:
+                # fetch resource
                 response = requests.get(resource_url)
                 response.raise_for_status()
-                save_name = self._id +"_"+urls[idx].split('/')[-1]
+
+                # write file to disk
+                save_name = self._id + "_" + urls[idx].split('/')[-1]
                 save_path = os.path.join(directory, save_name)
                 with open(save_path, 'wb+') as file:
                     file.write(response.content)
                 saved_files.append(save_path)
+
+                # log success
+                save_path = save_path.replace("/", "\\")
                 logging.info(f"Saved image to {save_path}")
+
             except requests.RequestException as e:
                 logging.error(f"Failed to download image from {resource_url}: {e}")
+
+            except Exception as e:
+                logging.error(f"Failed to save resource: {e}")
+        
         return saved_files
 
 
@@ -103,31 +122,38 @@ class ImageEntry(Entry):
 class AiGeneratedImageEntry(ImageEntry):
     pass
 
+
 @dataclass
 class VisionEntry(ImageEntry):
     pass
+
 
 class Journal:
     def __init__(self, max_entries: int):
         self.entries = deque(maxlen=max_entries)
         self.interactions = deque(maxlen=max_entries)
 
-    def add_entry(self, entry_data: Union[Dict[str, Any], str], llm_response: str = None):
+
+    def add_entry(self, entry_data: Union[Dict[str, Any], str], llm_response: str = None) -> Union[Entry, None]:
         '''
         Adds an entry to the journal.
         '''
         if isinstance(entry_data, str):
-            entry_data = self.create_basic_entry(entry_data)
+            entry_data = self._create_basic_entry(entry_data)
         
         try:
-            entry = self.create_entry(entry_data)
+            entry = self._create_entry(entry_data)
             self.entries.append(entry)
             if llm_response:
-                self.add_interaction(entry, llm_response)
+                self._add_interaction(entry, llm_response)
+            return entry
+        
         except (TypeError, ValueError) as e:
             print(f"Failed to instantiate entry: {e}")
 
-    def create_basic_entry(self, user_input: str) -> Dict[str, Any]:
+    
+
+    def _create_basic_entry(self, user_input: str) -> Dict[str, Any]:
         return {
             "_id": str(uuid.uuid1()),
             "userId": "local_user",
@@ -140,7 +166,7 @@ class Journal:
             "utterance": {"prompt": user_input, "intention": "CONVERSATION"}
         }
 
-    def create_entry(self, entry_data: Dict[str, Any]) -> Entry:
+    def _create_entry(self, entry_data: Dict[str, Any]) -> Entry:
         entry_type = entry_data['type']
         if entry_type == 'search':
             return SearchEntry(**entry_data)
@@ -155,7 +181,8 @@ class Journal:
         else:
             raise ValueError(f"Unknown entry type: {entry_type}")
 
-    def add_interaction(self, entry: Entry, llm_response: str):
+
+    def _add_interaction(self, entry: Entry, llm_response: str):
         interaction = {
             "_id": entry._id,
             "user prompt": entry.utterance['prompt'],
@@ -163,13 +190,16 @@ class Journal:
         }
         self.interactions.append(interaction)
 
+
     def last_entry(self) -> Union[Entry, None]:
         if self.entries:
             return self.entries[-1]
         return None
 
+
     def get_entries(self) -> List[Entry]:
         return list(self.entries)
+
 
     def get_entry_by_id(self, entry_id: str) -> Union[Entry, None]:
         for entry in self.entries:
@@ -177,24 +207,29 @@ class Journal:
                 return entry
         return None
     
+
     def get_entry_by_index(self, index: int) -> Union[Entry, None]:
         if 0 <= index < len(self.entries):
             return self.entries[index]
         return None
     
+
     def last_interaction(self) -> Union[Dict[str, str], None]:
         if self.interactions:
             return self.interactions[-1]
         return None
     
+
     def get_interactions(self) -> List[Dict[str, str]]:
         return list(self.interactions)
     
+
     def get_interaction_by_id(self, entry_id: str) -> Union[Dict[str, str], None]:
         for interaction in self.interactions:
             if interaction['_id'] == entry_id:
                 return interaction
         return None
+
 
     def get_interaction_by_index(self, index: int) -> Union[Dict[str, str], None]:
         if 0 <= index < len(self.interactions):


### PR DESCRIPTION
- added new function to LAH int called "save" (very creative, I know)
    - can save the resources of a given entry to the path specified on disk
    - resources for now only include images, with support for anything else easily addable in the future
    - accessible via new settings in `config.json`
        - `lamathomesave_isenabled` **:** `true|false`
	  `lamathomesave_types` **:** `["vision", "ai-generated-image"]`
	  `lamathomesave_path` **:** `~/Pictures/LAMatHome`
- fixed an issue where for journal entries with no prompts (like magic cam prompts or empty CLI inputs) LLMParse & task execution workflow would run anyway (they just skip now with a message indicating so)
- some small refactoring and cleanup